### PR TITLE
Mac OS version of tasks.json for C++

### DIFF
--- a/Config-Files/C&C++/MacOS/tasks.json
+++ b/Config-Files/C&C++/MacOS/tasks.json
@@ -1,7 +1,7 @@
-//Author : Juanjo12x
+// Author : Jota12x
 // Based on: 5hfT
-//data:17th Oct,2020
-//Task:shortcut to run a cpp file which will take input and show output of the programme automatically with programme runtime status such as memory comsume and execution time (Macbook)
+// Date:17th Oct,2020
+// Task:shortcut to run a cpp file which will take input and show output of the programme automatically with programme runtime status such as memory comsume and execution time (Macbook)
 {
   "version": "2.0.0",
   "tasks": [

--- a/Config-Files/C&C++/MacOS/tasks.json
+++ b/Config-Files/C&C++/MacOS/tasks.json
@@ -1,0 +1,50 @@
+//Author : Juanjo12x
+// Based on: 5hfT
+//data:17th Oct,2020
+//Task:shortcut to run a cpp file which will take input and show output of the programme automatically and delete possible debug files from using XCode
+{
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "Compile and run",
+        "type": "shell",
+        "command": "",
+        "args": [
+          "g++",
+          "-g",
+          "${relativeFile}",
+          "-o",
+          "${fileBasenameNoExtension}.out",
+          "&&",
+          "./${fileBasenameNoExtension}.out",
+          "<",
+          "input.txt",
+          ">",
+          "output.txt",
+          "&&",
+          "rm",
+          "*out",
+          "&&",
+          "rm",
+          "-r",
+          "*out.dSYM"
+        ],
+        "group": {
+          "kind": "build",
+          "isDefault": true
+        },
+        "problemMatcher": {
+          "owner": "cpp",
+          "fileLocation": ["relative", "${workspaceRoot}"],
+          "pattern": {
+            "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+            "file": 1,
+            "line": 2,
+            "column": 3,
+            "severity": 4,
+            "message": 5
+          }
+        }
+      }
+    ]
+}

--- a/Config-Files/C&C++/MacOS/tasks.json
+++ b/Config-Files/C&C++/MacOS/tasks.json
@@ -1,50 +1,52 @@
 //Author : Juanjo12x
 // Based on: 5hfT
 //data:17th Oct,2020
-//Task:shortcut to run a cpp file which will take input and show output of the programme automatically and delete possible debug files from using XCode
+//Task:shortcut to run a cpp file which will take input and show output of the programme automatically with programme runtime status such as memory comsume and execution time (Macbook)
 {
-    "version": "2.0.0",
-    "tasks": [
-      {
-        "label": "Compile and run",
-        "type": "shell",
-        "command": "",
-        "args": [
-          "g++",
-          "-g",
-          "${relativeFile}",
-          "-o",
-          "${fileBasenameNoExtension}.out",
-          "&&",
-          "./${fileBasenameNoExtension}.out",
-          "<",
-          "input.txt",
-          ">",
-          "output.txt",
-          "&&",
-          "rm",
-          "*out",
-          "&&",
-          "rm",
-          "-r",
-          "*out.dSYM"
-        ],
-        "group": {
-          "kind": "build",
-          "isDefault": true
-        },
-        "problemMatcher": {
-          "owner": "cpp",
-          "fileLocation": ["relative", "${workspaceRoot}"],
-          "pattern": {
-            "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
-            "file": 1,
-            "line": 2,
-            "column": 3,
-            "severity": 4,
-            "message": 5
-          }
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Compile and run",
+      "type": "shell",
+      "command": "",
+      "args": [
+        "g++",
+        "-g",
+        "${relativeFile}",
+        "-o",
+        "${fileBasenameNoExtension}.out",
+        "&&",
+        "/usr/bin/time",
+        "-lp",
+        "./${fileBasenameNoExtension}.out",
+        "<",
+        "input.txt",
+        ">",
+        "output.txt",
+        "&&",
+        "rm",
+        "*out",
+        "&&",
+        "rm",
+        "-r",
+        "*out.dSYM"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": {
+        "owner": "cpp",
+        "fileLocation": ["relative", "${workspaceRoot}"],
+        "pattern": {
+          "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
         }
       }
-    ]
+    }
+  ]
 }


### PR DESCRIPTION
### Problem:
I tried the Linux version of the `tasks.json` in vsCode but got an error so I extend it for Mac OS. 

### Problem:
Now the result of the execution is as follows:
![imagen](https://user-images.githubusercontent.com/6154802/96333394-9840da00-10a4-11eb-9c03-89f74c251b09.png)

I also included a line to delete possible debug files generated by XCode (https://stackoverflow.com/questions/584825/dsym-directories-while-compiling-c-code-in-macos)
