### PR TITLE
fix  `copy` command of `cmd` issue for special characters in file name

### DIFF
--- a/Config-Files/C&C++/Windows/tasks.json
+++ b/Config-Files/C&C++/Windows/tasks.json
@@ -10,7 +10,7 @@
       "command": "",
       "args": [
         "copy",
-        "${file}",
+        "\"${file}\"",
         "${workspaceFolder}\\jspwTest.cpp",
         "&&",
         "g++",


### PR DESCRIPTION
This is a fix for #13 issue.
Basically it was a issue for `copy` command of cmd in windows. `copy` command was not able to copy the files having special characters in the filename. 
For now, I have added double quotes in the filename so that `copy` command take the full name as a single filename.